### PR TITLE
Show settings

### DIFF
--- a/form/FidusWriterSettingsForm.inc.php
+++ b/form/FidusWriterSettingsForm.inc.php
@@ -51,7 +51,7 @@ class FidusWriterSettingsForm extends Form
     /**
      * Save settings.
      */
-    function execute($object = NULL)
+    function execute(...$functionArgs)
     {
         $plugin = $this->_plugin;
         $plugin->updateSetting(CONTEXT_ID_NONE, 'apiKey', trim($this->getData('apiKey'), "\"\';"), 'string');


### PR DESCRIPTION
This change is needed to avoid this error:

```
2022/08/06 00:10:53 [error] 449218#449218: *9 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Declaration of FidusWriterSettingsForm::execute($object = null) must be compatible with Form::execute(...$functionArgs) in /var/www/ojs/plugins/generic/fidusWriter/form/FidusWriterSettingsForm.inc.php on line 54" while reading response header from upstream, client: 188.151.237.49, server: DOMAIN.COM, request: "GET /index/$$$call$$$/grid/admin/plugins/admin-plugin-grid/manage?verb=settings&plugin=fiduswriterplugin&category=generic&_=1659744616536 HTTP/1.1", upstream: "fastcgi://unix:/run/php/php8.1-fpm.sock:", host: "DOMAIN.COM", referrer: "https://DOMAIN.COM/index/admin/settings"

```